### PR TITLE
Fix nuget package no strong name issue

### DIFF
--- a/Swashbuckle.AspNetCore.SwaggerGen.ConventionalRouting/Swashbuckle.AspNetCore.SwaggerGen.ConventionalRouting.csproj
+++ b/Swashbuckle.AspNetCore.SwaggerGen.ConventionalRouting/Swashbuckle.AspNetCore.SwaggerGen.ConventionalRouting.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.2.0" />
+    <PackageReference Include="StrongNamer" Version="0.2.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.5.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.5.1" />
   </ItemGroup>


### PR DESCRIPTION
The strong name check is mandatory for commercial software, as references to nuget packages without strong names will result in compilation errors.